### PR TITLE
Adding proxy configuration for osm tile server

### DIFF
--- a/roles/apache/templates/proxy.conf.j2
+++ b/roles/apache/templates/proxy.conf.j2
@@ -14,6 +14,8 @@
   RewriteRule ^{{ girder_mount_path }}$ {{ girder_mount_path }}/ [R]
   ProxyPass {{ girder_mount_path }}/ http://localhost:{{ girder_socket_port }}/
   ProxyPassReverse {{ girder_mount_path }}/ http://localhost:{{ girder_socket_port }}/
+  ProxyPass /tiles/ http://tile.openstreetmap.org/
+  ProxyPassReverse /tiles/ http://tile.openstreetmap.org/
   ProxyPass / http://localhost:{{ meteor_port }}/
   ProxyPassReverse / http://localhost:{{ meteor_port }}/
 </VirtualHost>


### PR DESCRIPTION
This goes with the PR at https://github.com/ecohealthalliance/diagnostic-dashboard/pull/71 to forward requests for openstreetmap tile images.  The diagnostic dashboard submodule also needs to be updated to contain those changes.
