### PR TITLE
Possible fix for deployment error

### DIFF
--- a/roles/girder/tasks/main.yml
+++ b/roles/girder/tasks/main.yml
@@ -138,13 +138,6 @@
     shell: "curl -u grits:{{girder_admin_password}} http://{{girder_socket_host}}:{{girder_socket_port}}/api/v1/user/authentication"
     register: token
 
-  - name: Enable plugins
-    shell: "curl -X PUT --data 'plugins={{girder_plugins|to_json}}&token={{(token.stdout|from_json)['authToken']['token']}}' http://{{girder_socket_host}}:{{girder_socket_port}}/api/v1/system/plugins"
-    register: plugin
-    notify: reload supervisor
-    with_items:
-      - girder
-
   - name: Copy healthmap import python script
     template:
       src: healthMapGirder.py


### PR DESCRIPTION
Error message:

```
TASK: [girder | Enable plugins] *********************************************** 
fatal: [54.204.158.176] => One or more undefined variables: 'dict object' has no attribute 'authToken'

FATAL: all hosts have already failed -- aborting

PLAY RECAP ******************************************************************** 
           to retry, use: --limit @/Users/frosario/site.retry

54.204.158.176             : ok=58   changed=9    unreachable=1    failed=0   
```

The problem might be that the json is parsed into a python dict which doesn't support dot syntax.
