### PR TITLE
Use consistent mongo_url variable

### DIFF
--- a/roles/download-classifier/tasks/main.yml
+++ b/roles/download-classifier/tasks/main.yml
@@ -24,7 +24,7 @@
   notify: restart grits api group
 
 - name: Loading mongo keywords used for annotation
-  shell: "{{ grits_env }}/bin/python {{ annie_prefix }}/mongo_import_keywords.py --mongo_url {{ lookup('env','MONGO_URL') }}"
+  shell: "{{ grits_env }}/bin/python {{ annie_prefix }}/mongo_import_keywords.py --mongo_url {{ mongo_url }}"
   args:
     chdir: "{{ grits_api_prefix }}"
   when: classifier_symlink.changed

--- a/roles/grits-api/templates/config.py.j2
+++ b/roles/grits-api/templates/config.py.j2
@@ -1,7 +1,7 @@
 aws_access_key = '{{ classifier_data_access_key | default("") }}'
 aws_secret_key = '{{ classifier_data_secret_key | default("") }}'
 BROKER_URL = '{{ celery_broker }}'
-mongo_url = 'mongodb://{{ ansible_eth0.ipv4.address }}:27017'
+mongo_url = 'mongodb://{{ mongo_url }}:27017'
 bing_translate_id = '{{ bing_translate_id | default("") }}'
 bing_translate_secret = '{{ bing_translate_secret | default("") }}'
 api_key = '{{ grits_api_key }}'


### PR DESCRIPTION
Using a consistent variable allows the mongo_url to be customized by passing in `--extra-vars "mongo_url="`
